### PR TITLE
Initialize mysqldump without column-statistics

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -24,6 +24,9 @@ class SqlMysql extends SqlBase
             // EMPTY password is not the same as NO password, and is valid.
             $contents = <<<EOT
 #This file was written by Drush's Sqlmysql.php.
+[mysqldump]
+column-statistics=0
+
 [client]
 user="{$dbSpec['username']}"
 password="{$dbSpec['password']}"


### PR DESCRIPTION
Starting in version 8, mysqldump expects column statistics to be part of the database information schema. However mysqldump does not check the mysql version of the server it is dumping the data from, and therefore will create an SQL statement that fails when targeting dbservers < version 8.

When mysqldump is installed, the default configuration is to disable this behavior, and as such most my.cnf files will generally include the switch that disables this. However, drush creates it's own config file to start mysql and mysqldump. This file is not combined with the system my.cnf files, and therefore needs this switch added to it in order to ensure that when it attempts to dump the database from a target system, it doesn't care that it's not a mysql8 database.